### PR TITLE
README: Safie API ReferenceのリンクURLを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ Safie APIを利用するためのサンプルコードです。
 
 Safie APIを利用開始するためには、[Safie Developers](https://developers.safie.link/)よりアカウント登録を行い、認証情報（アクセストークンもしくはAPIキー）を発行してください。詳しい手順については、[Safie Developersの使い方](https://developers.safie.link/tutorial/developers)を参照ください。
 
-また、Safie APIで提供する各APIの詳しい仕様は、[Safie API Reference](https://openapi.safie.link/redoc)を参照ください。
+また、Safie APIで提供する各APIの詳しい仕様は、[Safie API Reference](https://developers.safie.link/reference/api)を参照ください。


### PR DESCRIPTION
## 概要

README.md に記載されている Safie API Reference のリンクが無効になっていたため、正しいURLに修正しました。

## 変更内容

- 変更前: https://openapi.safie.link/redoc
- 変更後: https://developers.safie.link/reference/api